### PR TITLE
Added property for default Command prefix + other small changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -351,5 +351,9 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Rider IDE
+.idea/
+
 /Token.txt
 /Dockerfile

--- a/Bot.cs
+++ b/Bot.cs
@@ -40,6 +40,8 @@ namespace SilkBot
         [JsonProperty(PropertyName = "Guild Prefixes")]
         public static Dictionary<ulong, string> GuildPrefixes { get; set; }
 
+        public static string SilkDefaultCommandPrefix { get; } = "!";
+
 
         public DiscordClient Client { get; set; }
 
@@ -130,7 +132,7 @@ namespace SilkBot
                 return guild;
             }
 
-            guild = new Guild { DiscordGuildId = guildId, Prefix = "!" };
+            guild = new Guild { DiscordGuildId = guildId, Prefix = SilkDefaultCommandPrefix };
             return guild;
         }
 

--- a/Commands/Bot/GuildJoinHandler.cs
+++ b/Commands/Bot/GuildJoinHandler.cs
@@ -1,7 +1,6 @@
 ﻿using DSharpPlus;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
-using SilkBot.Utilities;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -25,12 +24,12 @@ namespace SilkBot.Commands.Bot
                 .WithThumbnail(e.Client.CurrentUser.AvatarUrl)
                 .WithFooter("Silk!", e.Client.CurrentUser.AvatarUrl)
                 .WithTimestamp(DateTime.Now);
-            embed.WithDescription("Thank you for chosing Silk! to join your server<3\n" +
+            embed.WithDescription("Thank you for choosing Silk! to join your server<3\n" +
                 "I am a relatively lightweight bot with many functions, partially in moderation" +
                 "partially in games, with many more features to come!\n" +
                 "If there's an issue, feel free to [open an issue on GitHub](https://github.com/VelvetThePanda/Silkbot/issues), or if you're not familiar with GitHub, feel free\n" +
                 "to message the developers directly via [p]support <your message>, where `[p]` is the prefix.\n" +
-                $"By default, the prefix is `!`, or <@{e.Client.CurrentUser.Id}>, but this can be changed by [p]prefix <your prefix here>.");
+                $"By default, the prefix is `{SilkDefaultCommandPrefix}`, or <@{e.Client.CurrentUser.Id}>, but this can be changed by [p]prefix <your prefix here>.");
             await firstChannel.SendMessageAsync(embed: embed);
 
         }

--- a/Commands/Bot/MessageCreationHandler.cs
+++ b/Commands/Bot/MessageCreationHandler.cs
@@ -30,7 +30,7 @@ namespace SilkBot.Commands.Bot
             CheckForInvite(e, config);
             Console.WriteLine($"Scanned for an invite in message in {CommandTimer.ElapsedMilliseconds} ms.");
             
-            var guildPrefix = config?.Prefix ?? "!";
+            var guildPrefix = config?.Prefix ?? SilkDefaultCommandPrefix;
             var prefixPos = e.Message.GetStringPrefixLength(guildPrefix);
             if (prefixPos < 1)
             {
@@ -46,6 +46,8 @@ namespace SilkBot.Commands.Bot
                 CommandTimer.Stop();
                 return;
             }
+            
+            /* NOTE: 'ExecuteCommandAsync' method is wrapped in a try/catch internally so Exceptions will not be rethrown from commands */
             _ = Task.Run(async () => await Instance.Client.GetCommandsNext().ExecuteCommandAsync(context));
             CommandTimer.Stop();
         }

--- a/Commands/Bot/RequisiteBotPermissions.cs
+++ b/Commands/Bot/RequisiteBotPermissions.cs
@@ -15,8 +15,8 @@ namespace SilkBot.Commands.Bot
         [HelpDescription("The bot's needed permissions, and what commands they affect.")]
         public async Task GetRequiredPermissions(CommandContext ctx)
         {
-
-            var prefix = SilkBot.Bot.Instance.SilkDBContext.Guilds.Where(guild => guild.DiscordGuildId == ctx.Guild.Id).AsEnumerable().Select(_ => _.Prefix);
+            var prefix = SilkBot.Bot.Instance.SilkDBContext.Guilds.FirstOrDefault(guild => guild.DiscordGuildId == ctx.Guild.Id)?.Prefix ?? SilkBot.Bot.SilkDefaultCommandPrefix;
+            
             var embed = EmbedHelper.CreateEmbed(ctx, "Permissions:", DiscordColor.CornflowerBlue);
             var bot = await ctx.Guild.GetMemberAsync(ctx.Client.CurrentUser.Id);
 
@@ -27,17 +27,17 @@ namespace SilkBot.Commands.Bot
 
             var sb = new StringBuilder();
 
-            sb.AppendLine($"`Manage Messages`: {(manageMessage ? ":white_check_mark:" : ":x:")}\nAffected commands: `{prefix}clear`, `{prefix}clean`; __error messages will persist if false.__");
-            sb.AppendLine($"`Manage Roles`: {(manageRoles ? ":white_check_mark:" : ":x:")}\nAffected commands: {prefix}role");
-            sb.AppendLine($"`Kick Members` {(kick ? ":white_check_mark:" : ":x:")}\nAffected commands: {prefix}kick");
-            sb.AppendLine($"`Ban Members` {(ban ? ":white_check_mark:" : ":x:")}\nAffected commands: {prefix}ban");
+            sb.AppendLine($"`Manage Messages`: {GetStatusEmoji(manageMessage)}\nAffected commands: `{prefix}clear`, `{prefix}clean`; __error messages will persist if false.__\n");
+            sb.AppendLine($"`Manage Roles`: {GetStatusEmoji(manageRoles)}\nAffected commands: `{prefix}role`\n");
+            sb.AppendLine($"`Kick Members` {GetStatusEmoji(kick)}\nAffected commands: `{prefix}kick`\n");
+            sb.AppendLine($"`Ban Members` {GetStatusEmoji(ban)}\nAffected commands: `{prefix}ban`\n");
 
             embed.WithTitle("Permissions:");
             embed.WithDescription(sb.ToString());
 
-
-
             await ctx.RespondAsync(embed: embed);
         }
+
+        private static string GetStatusEmoji(bool requirementMet) => requirementMet ? ":white_check_mark:" : ":x:";
     }
 }

--- a/Commands/Miscellaneous/UserInfo.cs
+++ b/Commands/Miscellaneous/UserInfo.cs
@@ -24,38 +24,47 @@ namespace SilkBot.Commands.Miscellaneous
 
             var status = "";
             DiscordEmoji emoji = null;
-            switch (member.Presence?.Status)
+            
+            try
             {
-                case UserStatus.Online:
-                    status = "Online";
-                    emoji = DiscordEmoji.FromGuildEmote(ctx.Client, 743339430672203796);
-                    break;
-                case UserStatus.Idle:
-                    status = "Idle";
-                    emoji = DiscordEmoji.FromGuildEmote(ctx.Client, 743339431720910889);
-                    break;
-                case UserStatus.DoNotDisturb:
-                    status = "Do Not Disturb";
-                    emoji = DiscordEmoji.FromGuildEmote(ctx.Client, 743339431632568450);
-                    break;
-                case UserStatus.Offline:
-                    status = "Offline";
-                    emoji = DiscordEmoji.FromGuildEmote(ctx.Client, 743339431905198100);
-                    break;
-                default:
-                    status = "Offline";
-                    emoji = DiscordEmoji.FromGuildEmote(ctx.Client, 743339431905198100);
-                    break;
+                switch (member.Presence?.Status)
+                {
+                    case UserStatus.Online:
+                        status = "Online";
+                        emoji = DiscordEmoji.FromGuildEmote(ctx.Client, 743339430672203796);
+                        break;
+                    case UserStatus.Idle:
+                        status = "Idle";
+                        emoji = DiscordEmoji.FromGuildEmote(ctx.Client, 743339431720910889);
+                        break;
+                    case UserStatus.DoNotDisturb:
+                        status = "Do Not Disturb";
+                        emoji = DiscordEmoji.FromGuildEmote(ctx.Client, 743339431632568450);
+                        break;
+                    case UserStatus.Offline:
+                        status = "Offline";
+                        emoji = DiscordEmoji.FromGuildEmote(ctx.Client, 743339431905198100);
+                        break;
+                    default:
+                        status = "Offline";
+                        emoji = DiscordEmoji.FromGuildEmote(ctx.Client, 743339431905198100);
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                // If here, emoji wasn't able to be grabbed from Guild and threw an exception
+                emoji = DiscordEmoji.FromName(ctx.Client, ":question:");
             }
 
             embed.AddField("Status:", $"{emoji}  {status}");
             embed.AddField("Name:", member.Username);
             embed.AddField("Creation Date:", GetCreationTime(member.CreationTimestamp) + " ago");
-            var roleList = new List<string>();
-            foreach (var role in member.Roles.OrderByDescending(r => r.Position))
-            {
-                roleList.Add(role.Mention);
-            }
+            
+            var roleList = member.Roles
+                .OrderByDescending(r => r.Position)
+                .Select(role => role.Mention)
+                .ToList();
 
             embed.AddField("Roles:", string.Join(' ', roleList));
 
@@ -68,7 +77,7 @@ namespace SilkBot.Commands.Miscellaneous
             var sb = new StringBuilder();
             if(creationTime.Days > 365)
             {
-                var years = creationTime.Days / 360;
+                var years = creationTime.Days / 365;
                 sb.Append($"{years} {(years > 1 ? "years" : "year")}, ");
                 creationTime = creationTime.Subtract(TimeSpan.FromDays(years * 365));
             }

--- a/Tools/TimedActionHelper.cs
+++ b/Tools/TimedActionHelper.cs
@@ -4,8 +4,10 @@ using System.Timers;
 
 namespace SilkBot.Tools
 {
-    public class TimedActionHelper
+    public class TimedActionHelper : IDisposable
     {
+        private bool _disposed;
+        
         public ConcurrentBag<TimedRestrictionAction> TimedRestrictedActions { get; } = new ConcurrentBag<TimedRestrictionAction>();
 
         public Timer Timer { get; } = new Timer(60000);
@@ -46,5 +48,29 @@ namespace SilkBot.Tools
                 }
             }
         }
+
+        #region Dispose Pattern
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                Timer?.Dispose();
+            }
+
+            _disposed = true;
+        }
+
+        #endregion
     }
 }

--- a/Tools/TimedRestrictionAction.cs
+++ b/Tools/TimedRestrictionAction.cs
@@ -3,10 +3,8 @@ using System;
 
 namespace SilkBot.Tools
 {
-    public class TimedRestrictionAction : IDisposable
+    public class TimedRestrictionAction
     {
-        private bool disposedValue;
-
         public RestrictionActionReason ActionReason { get; set; }
         public ulong Id { get; set; }
         public DiscordGuild Guild { get; set; }
@@ -15,21 +13,6 @@ namespace SilkBot.Tools
         
         public TimedRestrictionAction()
         {
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!disposedValue)
-            {
-                if (disposing){}
-                disposedValue = true;
-            }
-        }
-
-        public void Dispose()
-        {
-            Dispose(disposing: true);
-            GC.SuppressFinalize(this);
         }
     }
 }


### PR DESCRIPTION
Added property for default Command prefix to replace hardcoded '!' in strings and other places [magic strings scare me]); swapped IDisposable on classes (TimedActionHelper.cs was the class for it :D, TimedRestrictionAction.cs didn't need it)

.gitignore
- Added ignore for Jetbrains Rider IDE

GuildJoinHandler.cs
- Fixed spelling
- Changed hardcoded '!' with property for default prefix

MessageCreationHandler.cs
- Changed hardcoded '!' with property for default prefix
- Added comment for 'Task.Run' statement (if a command throws an Exception it will NOT be rethrown by CommandsNext.ExecuteCommandAsync method)

RequisiteBotPermissions.cs
- Changed 'prefix' LINQ query to return a single prefix for the guild or default prefix (was returning an IEnumerable<string>)
- Changed formatting for Embed (added newlines between permissions
- Made getting the status emoji a convenience method

UserInfo.cs
- Wrapped the switch for the user's presence and corresponding emoji in try/catch (will throw Exception if Emoji is not found in Guild)
- Condensed 'roleList' into LINQ query
- Fixed 'years' calculation (dividing by 360 vs 365)

Bot.cs
- Use property for default prefix instead of hardcoded '!'