### PR TITLE
Small clean up

### DIFF
--- a/Bot.cs
+++ b/Bot.cs
@@ -79,7 +79,7 @@
                 return guild;
             }
 
-            guild = new Guild { DiscordGuildId = guildId, Prefix = "!" };
+            guild = new Guild { DiscordGuildId = guildId, Prefix = SilkDefaultCommandPrefix };
             return guild;
         }
 

--- a/Commands/Bot/PrefixCommand.cs
+++ b/Commands/Bot/PrefixCommand.cs
@@ -56,7 +56,11 @@ namespace SilkBot.Commands.Bot
         [Command("Prefix")]
         public async Task SetPrefix(CommandContext ctx)
         {
-            await ctx.RespondAsync($"My prefix is `{new SilkDbContext().Guilds.FirstOrDefault(g => g.DiscordGuildId == ctx.Guild.Id).Prefix}`, but you can always use commands by mentioning me! ({ctx.Client.CurrentUser.Mention})");
+            using var db = new SilkDbContext();
+            var prefix = db.Guilds.FirstOrDefault(g => g.DiscordGuildId == ctx.Guild.Id)?.Prefix
+                         ?? SilkDefaultCommandPrefix;
+
+            await ctx.RespondAsync($"My prefix is `{prefix}`, but you can always use commands by mentioning me! ({ctx.Client.CurrentUser.Mention})");
         }
     }
 }

--- a/Commands/General/PingCommand.cs
+++ b/Commands/General/PingCommand.cs
@@ -40,7 +40,7 @@ namespace SilkBot.Commands.General
         private int GetDbLatency(ulong guildId)
         {
             var sw = Stopwatch.StartNew();
-            var db = new SilkDbContext();
+            using var db = new SilkDbContext();
             //_ = db.Guilds.First(_ => _.DiscordGuildId == guildId);
             db.Database.BeginTransaction();
             db.Database.ExecuteSqlRaw("SELECT * FROM Guilds;");

--- a/Commands/Moderation/Ban/BanFailureReason.cs
+++ b/Commands/Moderation/Ban/BanFailureReason.cs
@@ -2,13 +2,13 @@
 {
     public sealed class BanFailureReason
     {
-        public string FailiureReason { get; private set; }
-        public static string INSUFFICIENT_BOT_PERMISSIONS => "I can't ban memebers!";
+        public string FailureReason { get; private set; }
+        public static string INSUFFICIENT_BOT_PERMISSIONS => "I can't ban members!";
         public static string INSUFFICIENT_CALLER_PERMISSIONS => "You don't have permission to ban members!";
         public static string UNSUITABLE_HIERARCHY_POSITION => "I cannot ban $user due to roles.";
         public static string MODERATOR_BAN_ATTEMPT => "I can't ban $user; they're a staff member of this guild.";
 
-        public BanFailureReason(string reason) => FailiureReason = reason;
+        public BanFailureReason(string reason) => FailureReason = reason;
     }
    
 }

--- a/Commands/Moderation/Ban/TempBanCommand.cs
+++ b/Commands/Moderation/Ban/TempBanCommand.cs
@@ -17,7 +17,7 @@ namespace SilkBot.Commands.Moderation.Ban
         [Command("tempban")]
         public async Task TempBan(CommandContext ctx, DiscordMember user, string duration, [RemainingText] string reason = "Not provided.")
         {
-            var db = new SilkDbContext();
+            using var db = new SilkDbContext();
             var bot = await ctx.Guild.GetMemberAsync(ctx.Client.CurrentUser.Id);
             var now = DateTime.Now;
             var banDuration = GetTimeFromInput(duration);
@@ -26,7 +26,7 @@ namespace SilkBot.Commands.Moderation.Ban
 
             if (banFailed is null)
             {
-                embed.WithDescription(banFailed.FailiureReason.Replace("$user", user.Mention));
+                embed.WithDescription(banFailed.FailureReason.Replace("$user", user.Mention));
                 embed.WithColor(DiscordColor.Red);
                 await ctx.RespondAsync(embed: embed);
                 return;
@@ -66,7 +66,7 @@ namespace SilkBot.Commands.Moderation.Ban
 
         private async Task SendFailureMessage(CommandContext ctx, DiscordUser user, DiscordEmbedBuilder embed, BanFailureReason reason)
         {
-            embed.WithDescription(reason.FailiureReason.Replace("$user", user.Mention));
+            embed.WithDescription(reason.FailureReason.Replace("$user", user.Mention));
             embed.WithColor(DiscordColor.Red);
             await ctx.RespondAsync(embed: embed);
         }

--- a/Commands/Server/ConfigCommand.cs
+++ b/Commands/Server/ConfigCommand.cs
@@ -9,7 +9,7 @@ using DSharpPlus.Interactivity;
 using Microsoft.EntityFrameworkCore;
 using static SilkBot.Bot;
 
-namespace SilkBot.Commands.Tests
+namespace SilkBot.Commands.Server
 {
     public class ConfigCommand : BaseCommandModule
     {
@@ -18,7 +18,7 @@ namespace SilkBot.Commands.Tests
         [Command("configure")]
         public async Task GuildConfigurationCommand(CommandContext ctx)
         {
-            var db = new SilkDbContext();
+            using var db = new SilkDbContext();
             var a = db.Guilds.Include(_ => _.DiscordUserInfos).First(g => g.DiscordGuildId == ctx.Guild.Id);
             var guild = Instance.SilkDBContext.Guilds.First(g => g.DiscordGuildId == ctx.Guild.Id);
             if (!guild.DiscordUserInfos.Any(user => user.Flags.HasFlag(Models.UserFlag.Staff) && user.UserId == ctx.User.Id)) return;

--- a/Commands/Server/WhitelistInviteCommand.cs
+++ b/Commands/Server/WhitelistInviteCommand.cs
@@ -1,9 +1,9 @@
-﻿using DSharpPlus.CommandsNext;
-using DSharpPlus.CommandsNext.Attributes;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
+using DSharpPlus.CommandsNext;
+using DSharpPlus.CommandsNext.Attributes;
 
-namespace SilkBot.Commands.Tests
+namespace SilkBot.Commands.Server
 {
     public class WhitelistInviteCommand : BaseCommandModule
     {


### PR DESCRIPTION
Small clean up (PrefixCommand, PingCommand, TempBanCommand, and ConfigCommand  make use of variable for DbContext to use 'using' declaration to dispose of context after method scope)

BanFailureReason.cs
- Small spelling change for property and in the string constant

ConfigCommand.cs
- Changed namespace to proper location folder structure wise

WhitelistInviteCommand.cs
- Changed namespace to proper location folder structure wise

Bot.cs
- Uses string constant for default prefix