### PR TITLE
Removal of local project references

### DIFF
--- a/Silk_Core/Silk_Core.csproj
+++ b/Silk_Core/Silk_Core.csproj
@@ -107,7 +107,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\DSharpPlus\DSharpPlus.Interactivity\DSharpPlus.Interactivity.csproj" />
     <ProjectReference Include="..\Silk_Extensions\Silk_Extensions.csproj" />
   </ItemGroup>
 

--- a/Silk_Extensions/Silk_Extensions.csproj
+++ b/Silk_Extensions/Silk_Extensions.csproj
@@ -13,16 +13,12 @@
   <ItemGroup>
     <PackageReference Include="DSharpPlus" Version="4.0.0-rc1" />
     <PackageReference Include="DSharpPlus.CommandsNext" Version="4.0.0-rc1" />
+    <PackageReference Include="DSharpPlus.Interactivity" Version="4.0.0-rc1" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\DSharpPlus\DSharpPlus.CommandsNext\DSharpPlus.CommandsNext.csproj" />
-    <ProjectReference Include="..\..\DSharpPlus\DSharpPlus\DSharpPlus.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Removed local project references to "DSharpPlus" and "DSharpPlus.Interactivity" projects in .csproj files for Silk_Core + Silk_Extensions
- Added NuGet for "DSharpPlus.Interactivity" to Silk_Extensions project