### PR TITLE
Small changes + 1 null check

### DIFF
--- a/Silk_Core/Bot.cs
+++ b/Silk_Core/Bot.cs
@@ -104,12 +104,16 @@ namespace SilkBot
             _eventHelper.CreateHandlers();
             
             var cmdNext = await Client.GetCommandsNextAsync();
-            foreach (CommandsNextExtension c in cmdNext.Values) c.SetHelpFormatter<HelpFormatter>();
-            foreach (CommandsNextExtension c in cmdNext.Values) c.RegisterConverter(new MemberConverter());
+            foreach (CommandsNextExtension c in cmdNext.Values)
+            {
+                c.SetHelpFormatter<HelpFormatter>(); 
+                c.RegisterConverter(new MemberConverter());
+            }
+            
             _logger.LogInformation("Client Initialized.");
             _logger.LogInformation($"Startup time: {DateTime.Now.Subtract(Program.Startup).Seconds} seconds.");
             
-            Client.Ready += async (c, e) => _logger.LogInformation("Client ready to proccess commands.");
+            Client.Ready += async (c, e) => _logger.LogInformation("Client ready to process commands.");
         }
 
         public async Task StartAsync(CancellationToken cancellationToken)

--- a/Silk_Core/Commands/CommandProcessorModule.cs
+++ b/Silk_Core/Commands/CommandProcessorModule.cs
@@ -20,18 +20,18 @@ namespace SilkBot.Commands
             _prefixCache = prefixCache;
         }
 
-        public static void DisableCommand(string command, ulong id)
+        public static void DisableCommand(string command, ulong guildId)
         {
-            disabledCommandsCache.TryGetValue(id, out var value);
-            if (value is not null)
+            disabledCommandsCache.TryGetValue(guildId, out var guildDisabledCommands);
+            if (guildDisabledCommands is not null)
             {
-                value.Add(command);
+                guildDisabledCommands.Add(command);
             }
             else
             {
-                value = new();
-                value.Add(command);
-                disabledCommandsCache.TryAdd(id, value);
+                guildDisabledCommands = new();
+                guildDisabledCommands.Add(command);
+                disabledCommandsCache.TryAdd(guildId, guildDisabledCommands);
             }
         }
         public async Task OnMessageCreate(DiscordClient c, MessageCreateEventArgs e)

--- a/Silk_Core/Services/PrefixCacheService.cs
+++ b/Silk_Core/Services/PrefixCacheService.cs
@@ -39,33 +39,35 @@ namespace SilkBot.Services
         public string? RetrievePrefix(ulong? guildId)
         {
             if (guildId == default || guildId == 0) return null;
-            else if (_cache.TryGetValue(guildId.Value, out string? prefix)) return prefix;
-            else return GetPrefixFromDatabase(guildId.Value);
+            if (_cache.TryGetValue(guildId.Value, out string? prefix)) return prefix;
+            return GetPrefixFromDatabase(guildId.Value);
         }
 
         private string GetPrefixFromDatabase(ulong guildId)
         {
             _logger.LogDebug("Prefix not present in cache; queuing from database.");
             _sw.Restart();
+            
             using SilkDbContext db = _dbFactory.CreateDbContext();
-
-
+            
             GuildModel? guild = db.Guilds.AsNoTracking().FirstOrDefault(g => g.Id == guildId);
             if (guild is null)
             {
                 _logger.LogCritical("Guild was not cached on join, and therefore does not exist in database.");
                 return Bot.DefaultCommandPrefix;
             }
-            _logger.LogDebug($"Cached {guild.Prefix} - {guildId} in {_sw.ElapsedMilliseconds} ms.");
+
             _sw.Stop();
+            _logger.LogDebug($"Cached {guild.Prefix} - {guildId} in {_sw.ElapsedMilliseconds} ms.");
             _cache.TryAdd(guildId, guild.Prefix);
+            
             return guild.Prefix;
         }
 
         public void UpdatePrefix(ulong id, string prefix)
         {
             _cache.TryGetValue(id, out string? currentPrefix);
-            _cache.AddOrUpdate(id, prefix, (i, p) => p = prefix);
+            _cache.AddOrUpdate(id, prefix, (i, p) => prefix);
             _logger.LogDebug($"Updated prefix for {id} - {currentPrefix} -> {prefix}");
         }
     }

--- a/Silk_Core/Utilities/HelpFormatter.cs
+++ b/Silk_Core/Utilities/HelpFormatter.cs
@@ -61,11 +61,14 @@ namespace SilkBot.Utilities
                 IReadOnlyList<CommandArgument> args = Command.Overloads.OrderByDescending(x => x.Priority)
                                                              .FirstOrDefault()?.Arguments;
                 var title = new StringBuilder($"Command `{Command.QualifiedName}");
-                foreach (CommandArgument arg in args)
+                if (args is not null)
                 {
-                    title.Append(arg.IsOptional ? " [" : " <");
-                    title.Append(arg.Name);
-                    title.Append(arg.IsOptional ? "]" : ">");
+                    foreach (CommandArgument arg in args)
+                    {
+                        title.Append(arg.IsOptional ? " [" : " <");
+                        title.Append(arg.Name);
+                        title.Append(arg.IsOptional ? "]" : ">");
+                    }
                 }
 
                 title.Append('`');


### PR DESCRIPTION
CommandProcessorModule.cs
- Made variable names a bit more readable in their context

PrefixCacheService.cs
- Stop the stopwatch before logging
- UpdatePrefix uses the 'prefix' parameter, instead of overwriting the provided 'p' in the function lambda

HelpFormatter.cs
- Added a null check for 'args' (exception happens when trying to execute: "[prefix]help sclean")

Bot.cs
- Merge setting the commands help formatter and registering converters in one loop instead of two separate loops