### PR TITLE
Using IHttpClientFactory + Updated permissions for ClearCommand

### DIFF
--- a/Silk_Core/Commands/Economy/DailyCommand.cs
+++ b/Silk_Core/Commands/Economy/DailyCommand.cs
@@ -25,7 +25,7 @@ namespace SilkBot.Commands.Economy
         }
 
         [Command("Daily")]
-        [RequireGuild()]
+        [RequireGuild]
         public async Task DailyMoney(CommandContext ctx)
         {
             using SilkDbContext db = _dbFactory.CreateDbContext();

--- a/Silk_Core/Commands/Economy/DonateCommand.cs
+++ b/Silk_Core/Commands/Economy/DonateCommand.cs
@@ -49,7 +49,7 @@ namespace SilkBot.Commands.Economy
                     "I'd love to duplicate money just as much as the next person, but we have an economy!");
             else if (sender.Cash < amount)
                 await ctx.RespondAsync($"You're {amount - sender.Cash} dollars too short for that, I'm afraid.");
-            else if (amount >= 1000) await VerifyTransationAsync(ctx, sender, receiver, amount);
+            else if (amount >= 1000) await VerifyTransactionAsync(ctx, sender, receiver, amount);
             else await DoTransactionAsync(ctx, amount, sender, receiver);
 
             await db.SaveChangesAsync();
@@ -69,7 +69,7 @@ namespace SilkBot.Commands.Economy
             await ctx.RespondAsync(embed: embed);
         }
 
-        private async Task VerifyTransationAsync(CommandContext ctx, GlobalUserModel sender, GlobalUserModel receiver,
+        private async Task VerifyTransactionAsync(CommandContext ctx, GlobalUserModel sender, GlobalUserModel receiver,
             int amount)
         {
             // 'Complicated async logic here' //

--- a/Silk_Core/Commands/Furry/NSFW/e621Command.cs
+++ b/Silk_Core/Commands/Furry/NSFW/e621Command.cs
@@ -18,7 +18,7 @@ namespace SilkBot.Commands.Furry.NSFW
     {
         
         private readonly BotConfig _config;
-        public e621Command(HttpClient client, BotConfig config) : base(client)
+        public e621Command(IHttpClientFactory httpClientFactory, BotConfig config) : base(httpClientFactory)
         {
             baseUrl = "https://e621.net/posts.json?tags=";
             _config = config;
@@ -36,7 +36,8 @@ namespace SilkBot.Commands.Furry.NSFW
                 await ctx.RespondAsync("You can search 5 tags at a time!");
                 return;
             }
-            else if (amount > 10)
+
+            if (amount > 10)
             {
                 await ctx.RespondAsync("You can only request 10 images every 10 seconds.");
                 return;
@@ -57,6 +58,7 @@ namespace SilkBot.Commands.Furry.NSFW
             foreach (Post? post in posts)
             {
                 //if (post is null) continue;
+                // TODO: Handle Null Exception for parts of the post which may be null (i.e image source)
                 DiscordEmbedBuilder embed = new DiscordEmbedBuilder()
                                             .WithTitle(query)
                                             .WithDescription(

--- a/Silk_Core/Commands/Furry/SFW/e926Command.cs
+++ b/Silk_Core/Commands/Furry/SFW/e926Command.cs
@@ -17,7 +17,7 @@ namespace SilkBot.Commands.Furry.SFW
     [Cooldown(1, 15, CooldownBucketType.User)]
     public class e926Command : eBooruBaseCommand
     {
-        public e926Command(HttpClient client) : base(client)
+        public e926Command(IHttpClientFactory httpClientFactory) : base(httpClientFactory)
         {
             baseUrl = "https://e926.net/posts.json?tags=";
         }

--- a/Silk_Core/Commands/Furry/Utilities/eBooruBaseCommand.cs
+++ b/Silk_Core/Commands/Furry/Utilities/eBooruBaseCommand.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
 using Newtonsoft.Json;
+using SilkBot.Utilities;
 
 namespace SilkBot.Commands.Furry.Utilities
 {
@@ -18,9 +19,9 @@ namespace SilkBot.Commands.Furry.Utilities
         
         private protected readonly HttpClient _client;
 
-        public eBooruBaseCommand(HttpClient client)
+        public eBooruBaseCommand(IHttpClientFactory httpClientFactory)
         {
-            _client = client;
+            _client = httpClientFactory.CreateSilkClient();
         }
 
         /// <summary>

--- a/Silk_Core/Commands/General/ClearCommand.cs
+++ b/Silk_Core/Commands/General/ClearCommand.cs
@@ -21,7 +21,7 @@ namespace SilkBot.Commands.General
             int messages = 5)
         {
             // Anyone who's got permission to manage channels might not be staff, so adding [RequireFlag(UserFlag.Staff)] needlessly permwalls it. //
-            if (!ctx.Member.HasPermission(Permissions.ManageChannels))
+            if (!ctx.Member.HasPermission(Permissions.ManageMessages))
             {
                 await ctx.RespondAsync(embed: new DiscordEmbedBuilder()
                                               .WithAuthor(ctx.Member.DisplayName, null, ctx.Member.AvatarUrl)

--- a/Silk_Core/Commands/Server/ConfigCommand.cs
+++ b/Silk_Core/Commands/Server/ConfigCommand.cs
@@ -28,9 +28,9 @@ namespace SilkBot.Commands.Server
         private readonly HttpClient _client;
         private readonly IDbContextFactory<SilkDbContext> _dbFactory;
 
-        public ConfigCommand(HttpClient client, IDbContextFactory<SilkDbContext> factory)
+        public ConfigCommand(IHttpClientFactory httpClientFactory, IDbContextFactory<SilkDbContext> factory)
         {
-            _client = client;
+            _client = httpClientFactory.CreateSilkClient();
             _dbFactory = factory;
         }
 

--- a/Silk_Core/Program.cs
+++ b/Silk_Core/Program.cs
@@ -6,7 +6,9 @@ using DSharpPlus;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Serilog;
@@ -27,6 +29,7 @@ namespace SilkBot
     public class Program
     {
         public static DateTime Startup { get; } = DateTime.Now;
+        public static string HttpClientName { get; } = "VelvetThePandaSilkBot";
 
         private static readonly DiscordConfiguration _clientConfig = new()
         {
@@ -88,13 +91,18 @@ namespace SilkBot
                            
                            services.AddSingleton<SerilogLoggerFactory>();
                            services.AddSingleton<CommandProcessorModule>();
-                           
-                           services.AddSingleton(typeof(HttpClient), _ =>
+
+                           services.AddHttpClient(HttpClientName, client =>
                            {
-                               var client = new HttpClient();
                                client.DefaultRequestHeaders.UserAgent.ParseAdd("Silk Project by VelvetThePanda / v1.4");
-                               return client;
                            });
+                           
+                           // Sub out the default implementation filter with custom filter
+                           services.Replace(ServiceDescriptor.Singleton<IHttpMessageHandlerBuilderFilter, CustomLoggingFilter>());
+
+                           /* Can remove all filters with this line */
+                           // services.RemoveAll<IHttpMessageHandlerBuilderFilter>();
+
                            services.AddTransient(_ => new BotConfig(config));
                            
                            services.AddHostedService<Bot>();

--- a/Silk_Core/Silk_Core.csproj
+++ b/Silk_Core/Silk_Core.csproj
@@ -65,6 +65,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.0" />
     <PackageReference Include="Serilog" Version="2.10.1-dev-01256" />

--- a/Silk_Core/Utilities/CustomLoggingFilter.cs
+++ b/Silk_Core/Utilities/CustomLoggingFilter.cs
@@ -1,0 +1,39 @@
+using System;
+using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Logging;
+
+namespace SilkBot.Utilities
+{
+    /// <summary>
+    /// Overriding Logging Filter for HttpClientFactory
+    /// Source: https://www.stevejgordon.co.uk/httpclientfactory-asp-net-core-logging
+    /// </summary>
+    public class CustomLoggingFilter : IHttpMessageHandlerBuilderFilter
+    {
+        private readonly ILoggerFactory _loggerFactory;
+
+        public CustomLoggingFilter(ILoggerFactory loggerFactory)
+        {
+            _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+        }
+
+        public Action<HttpMessageHandlerBuilder> Configure(Action<HttpMessageHandlerBuilder> next)
+        {
+            if (next == null)
+            {
+                throw new ArgumentNullException(nameof(next));
+            }
+
+            return builder =>
+            {
+                // Run other configuration first, we want to decorate.
+                next(builder);
+
+                var outerLogger =
+                    _loggerFactory.CreateLogger($"System.Net.Http.HttpClient.{builder.Name}.LogicalHandler");
+
+                builder.AdditionalHandlers.Insert(0, new CustomLoggingScopeHttpMessageHandler(outerLogger));
+            };
+        }
+    }
+}

--- a/Silk_Core/Utilities/CustomLoggingScopeHttpMessageHandler.cs
+++ b/Silk_Core/Utilities/CustomLoggingScopeHttpMessageHandler.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace SilkBot.Utilities
+{
+    /// <summary>
+    /// Overriding Logging Scope Handler for HttpClientFactory
+    /// Source: https://www.stevejgordon.co.uk/httpclientfactory-asp-net-core-logging
+    /// </summary>
+    public class CustomLoggingScopeHttpMessageHandler : DelegatingHandler
+    {
+        private readonly ILogger _logger;
+
+        public CustomLoggingScopeHttpMessageHandler(ILogger logger)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            using (Log.BeginRequestPipelineScope(_logger, request))
+            {
+                Log.RequestPipelineStart(_logger, request);
+                var response = await base.SendAsync(request, cancellationToken);
+                Log.RequestPipelineEnd(_logger, response);
+
+                return response;
+            }
+        }
+
+        private static class Log
+        {
+            private static class EventIds
+            {
+                public static readonly EventId PipelineStart = new(100, "RequestPipelineStart");
+                public static readonly EventId PipelineEnd = new(101, "RequestPipelineEnd");
+            }
+
+            private static readonly Func<ILogger, HttpMethod, Uri, IDisposable> _beginRequestPipelineScope =
+                LoggerMessage.DefineScope<HttpMethod, Uri>(
+                    "HTTP {HttpMethod} {Uri}");
+
+            private static readonly Action<ILogger, HttpMethod, Uri, Exception> _requestPipelineStart =
+                LoggerMessage.Define<HttpMethod, Uri>(
+                    LogLevel.Information,
+                    EventIds.PipelineStart,
+                    "Start processing HTTP request {HttpMethod} {Uri}");
+
+            private static readonly Action<ILogger, HttpStatusCode, Exception> _requestPipelineEnd =
+                LoggerMessage.Define<HttpStatusCode>(
+                    LogLevel.Information,
+                    EventIds.PipelineEnd,
+                    "End processing HTTP request - {StatusCode}");
+
+            public static IDisposable BeginRequestPipelineScope(ILogger logger, HttpRequestMessage request)
+            {
+                return _beginRequestPipelineScope(logger, request.Method, request.RequestUri);
+            }
+
+            public static void RequestPipelineStart(ILogger logger, HttpRequestMessage request)
+            {
+                _requestPipelineStart(logger, request.Method, request.RequestUri, null);
+            }
+
+            public static void RequestPipelineEnd(ILogger logger, HttpResponseMessage response)
+            {
+                _requestPipelineEnd(logger, response.StatusCode, null);
+            }
+        }
+    }
+}

--- a/Silk_Core/Utilities/HttpClientExtensions.cs
+++ b/Silk_Core/Utilities/HttpClientExtensions.cs
@@ -1,0 +1,12 @@
+﻿using System.Net.Http;
+
+namespace SilkBot.Utilities
+{
+    public static class HttpClientExtensions
+    {
+        public static HttpClient CreateSilkClient(this IHttpClientFactory httpClientFactory)
+        {
+            return httpClientFactory.CreateClient(Program.HttpClientName);
+        }
+    }
+}


### PR DESCRIPTION
- Using IHttpClientFactory for creating instances of HttpClient to prevent resource exhaustion
- Added override for HttpClient Logging (default implementation for logging filter provides a lot of output)
- Updated permissions for ClearCommand, now checks for ManageMessages (command checked for ManageChannels but message stated it needed ManageMessages)
- Corrected typo in DonateCommand's "VerifyTransactionAsync" method